### PR TITLE
Added podspec - not published yet in Cocoapods due to missing Git tag

### DIFF
--- a/IDTwitterAccountChooserViewController.podspec
+++ b/IDTwitterAccountChooserViewController.podspec
@@ -1,0 +1,31 @@
+Pod::Spec.new do |s|
+
+  s.name         = "IDTwitterAccountChooserViewController"
+  s.version      = "1.0.0"
+  s.summary      = "Twitter Account Chooser view controller for iOS 6+"
+
+  s.description  = <<-DESC
+                   Twitter Account Chooser view controller for iOS 6+. Uses a block-based completion handler or a classic protocol-based delegate method.
+		   DESC
+
+  s.homepage     = "https://github.com/idevsoftware/IDTwitterAccountChooserViewController"
+  s.screenshots  = "https://raw.githubusercontent.com/idevsoftware/IDTwitterAccountChooserViewController/master/screenshot.png"
+
+  s.license      = { :type => "MIT", :text => "Licensed under the MIT license\n\nCopyright by @iDevSoftware 2012" }
+
+  s.author    	 = "iDev Software"
+
+  s.platform     = :ios, "6.0"
+
+  s.source       = { 
+	:git => "https://github.com/idevsoftware/IDTwitterAccountChooserViewController.git",
+	:commit => "2f8b1b04fc7db5c0a2cc57c2d9ae60bd62663487",
+	:tag => s.version.to_s }
+
+  s.source_files = "IDTwitterAccountChooserViewController.{h,m}"
+
+  s.public_header_files = "IDTwitterAccountChooserViewController.h"
+
+  s.weak_frameworks = "UIKit", "Accounts", "Social"
+
+end

--- a/IDTwitterAccountChooserViewController.podspec
+++ b/IDTwitterAccountChooserViewController.podspec
@@ -17,10 +17,7 @@ Pod::Spec.new do |s|
 
   s.platform     = :ios, "6.0"
 
-  s.source       = { 
-	:git => "https://github.com/idevsoftware/IDTwitterAccountChooserViewController.git",
-	:commit => "2f8b1b04fc7db5c0a2cc57c2d9ae60bd62663487",
-	:tag => s.version.to_s }
+  s.source       = { :git => "https://github.com/idevsoftware/IDTwitterAccountChooserViewController.git", :tag => s.version.to_s }
 
   s.source_files = "IDTwitterAccountChooserViewController.{h,m}"
 


### PR DESCRIPTION
@idevsoftware, Please add Git tag "1.0.0" or whatever you'll specify in the podspec's 's.version' in order to pass Cocoapods requirements.

'pod spec lint' currently fails due to missing Git tag. when this is fixed, the podspec can be tested locally and published to Cocoapods.

If you prefer to publish it yourself, it's fine with me. just let me know if you want me to test this.
If I will publish it, I can add your email address as another owner for this pod.
